### PR TITLE
Removed URL from MatrixQ and RegionA ID's, as theyre not actually ID's.

### DIFF
--- a/QuAnGIS/No1/constraints10.json
+++ b/QuAnGIS/No1/constraints10.json
@@ -5,8 +5,8 @@
 	  "description": "", 
       "parameters": [
        {
-        "CoreConceptQ": [ "http://geographicknowledge.de/vocab/CoreConceptData.rdf#MatrixQ"],
-	"LayerA":	["http://geographicknowledge.de/vocab/CoreConceptData.rdf#RegionA"],
+        "CoreConceptQ": [ "MatrixQ"],
+	"LayerA":	["RegionA"],
 	"NominalA":	["http://geographicknowledge.de/vocab/ExtensiveMeasures.rdf#ERA"]
 	}		
 	]


### PR DESCRIPTION
ERA still has a url.