### PR TITLE
Add CWL generation configuration for APE CI

### DIFF
--- a/GeoGMT/E0/config.json
+++ b/GeoGMT/E0/config.json
@@ -12,6 +12,7 @@
   "max_solutions": "1000",
   "number_of_execution_scripts": "1",
   "number_of_generated_graphs": "5",
+  "number_of_cwl_files": "1",
   "tool_seq_repeat": "true",
   "inputs": [
     {


### PR DESCRIPTION
Adds CWL generation configuration to the GeoGMT E0 usecase. This will be used by the CI of APE to test the CWL export functionality.