### PR TITLE
Fix spelling mistake of ontologyPrexifIRI to ontologyPrefixIRI

### DIFF
--- a/GeoGMT/E0/config.json
+++ b/GeoGMT/E0/config.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./GeoGMT/GMT_UseCase_taxonomy.owl",
-  "ontologyPrexifIRI": "http://www.co-ode.org/ontologies/ont.owl#",
+  "ontologyPrefixIRI": "http://www.co-ode.org/ontologies/ont.owl#",
   "toolsTaxonomyRoot": "ToolsTaxonomy",
   "dataDimensionsTaxonomyRoots": ["TypesTaxonomy"],
   "tool_annotations_path": "./GeoGMT/tool_annotations.json",

--- a/GeoGMT/E1/config.json
+++ b/GeoGMT/E1/config.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./GeoGMT/GMT_UseCase_taxonomy.owl",
-  "ontologyPrexifIRI": "http://www.co-ode.org/ontologies/ont.owl#",
+  "ontologyPrefixIRI": "http://www.co-ode.org/ontologies/ont.owl#",
   "toolsTaxonomyRoot": "ToolsTaxonomy",
   "dataDimensionsTaxonomyRoots": ["TypesTaxonomy"],
   "tool_annotations_path": "./GeoGMT/tool_annotations.json",

--- a/ImageMagick/Example1/config.json
+++ b/ImageMagick/Example1/config.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./ImageMagick/imagemagick_taxonomy.owl",
-  "ontologyPrexifIRI": "http://www.co-ode.org/ontologies/ont.owl#",
+  "ontologyPrefixIRI": "http://www.co-ode.org/ontologies/ont.owl#",
   "toolsTaxonomyRoot": "Tool",
   "dataDimensionsTaxonomyRoots": [ "Type", "Format"],
   "tool_annotations_path": "./ImageMagick/tool_annotations.json",

--- a/ImageMagick/Example2/config.json
+++ b/ImageMagick/Example2/config.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./ImageMagick/imagemagick_taxonomy.owl",
-  "ontologyPrexifIRI": "http://www.co-ode.org/ontologies/ont.owl#",
+  "ontologyPrefixIRI": "http://www.co-ode.org/ontologies/ont.owl#",
   "toolsTaxonomyRoot": "Tool",
   "dataDimensionsTaxonomyRoots": [ "Type", "Format"],
   "tool_annotations_path": "./ImageMagick/tool_annotations.json",

--- a/MassSpectometry/No1/config_extended.json
+++ b/MassSpectometry/No1/config_extended.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/bio.tools_proteomics_domain.json",

--- a/MassSpectometry/No1/config_full_bio.tools.json
+++ b/MassSpectometry/No1/config_full_bio.tools.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/full_bio.tools.json",

--- a/MassSpectometry/No1/config_original.json
+++ b/MassSpectometry/No1/config_original.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/bio.tools_fragment.json",

--- a/MassSpectometry/No2/config_extended.json
+++ b/MassSpectometry/No2/config_extended.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/bio.tools_proteomics_domain.json",

--- a/MassSpectometry/No2/config_full_bio.tools.json
+++ b/MassSpectometry/No2/config_full_bio.tools.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/full_bio.tools.json",

--- a/MassSpectometry/No2/config_original.json
+++ b/MassSpectometry/No2/config_original.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/bio.tools_fragment.json",

--- a/MassSpectometry/No3/config_extended.json
+++ b/MassSpectometry/No3/config_extended.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/bio.tools_proteomics_domain.json",

--- a/MassSpectometry/No3/config_full_bio.tools.json
+++ b/MassSpectometry/No3/config_full_bio.tools.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/full_bio.tools.json",

--- a/MassSpectometry/No3/config_original.json
+++ b/MassSpectometry/No3/config_original.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/bio.tools_fragment.json",

--- a/MassSpectometry/No4/config_extended.json
+++ b/MassSpectometry/No4/config_extended.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/bio.tools_proteomics_domain.json",

--- a/MassSpectometry/No4/config_full_bio.tools.json
+++ b/MassSpectometry/No4/config_full_bio.tools.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/full_bio.tools.json",

--- a/MassSpectometry/No4/config_original.json
+++ b/MassSpectometry/No4/config_original.json
@@ -1,6 +1,6 @@
 {
   "ontology_path": "./MassSpectometry/edam.owl",
-  "ontologyPrexifIRI": "http://edamontology.org/",
+  "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915" ],
   "tool_annotations_path": "./MassSpectometry/bio.tools_fragment.json",

--- a/QuAnGIS/No1/config.json
+++ b/QuAnGIS/No1/config.json
@@ -1,5 +1,5 @@
 {
- "ontologyPrexifIRI": "http://geographicknowledge.de/vocab/CoreConceptData.rdf#",
+ "ontologyPrefixIRI": "http://geographicknowledge.de/vocab/CoreConceptData.rdf#",
   "solutions_dir_path": "./QuAnGIS/No1/", 
   "tool_annotations_path": "./QuAnGIS/FlowmapDescription.json",
   "strict_tool_annotations": "false",


### PR DESCRIPTION
The APE configuration file had an element with a spelling mistake: `ontologyPrexifIRI`. It has been fixed by [this PR](https://github.com/sanctuuary/APE/pull/57). The use cases need to be updated as well.