### PR TITLE
Rename "max_solutions" configuration element to "solutions"

### DIFF
--- a/GeoGMT/E0/config.json
+++ b/GeoGMT/E0/config.json
@@ -9,7 +9,7 @@
   "timeout_sec": "20",
   "solutions_dir_path": "./GeoGMT/E0/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "1",
   "number_of_generated_graphs": "5",
   "number_of_cwl_files": "1",

--- a/GeoGMT/E1/config.json
+++ b/GeoGMT/E1/config.json
@@ -9,7 +9,7 @@
   "timeout_sec": "20",
   "solutions_dir_path": "./GeoGMT/E1/",
   "solution_length": { "min": 1, "max": 18 },
-  "max_solutions": "100",
+  "solutions": "100",
   "number_of_execution_scripts": "6",
   "number_of_generated_graphs": "10",
   "tool_seq_repeat": "false",

--- a/ImageMagick/Example1/config.json
+++ b/ImageMagick/Example1/config.json
@@ -9,7 +9,7 @@
   "timeout_sec": "20",
   "solutions_dir_path": "./ImageMagick/Example1/",
   "solution_length": { "min": 1, "max": 8 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "1",
   "number_of_generated_graphs": "1",
   "tool_seq_repeat": "true",

--- a/ImageMagick/Example2/config.json
+++ b/ImageMagick/Example2/config.json
@@ -9,7 +9,7 @@
   "timeout_sec": "20",
   "solutions_dir_path": "./ImageMagick/Example2/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "2",
   "number_of_generated_graphs": "2",
   "tool_seq_repeat": "true",

--- a/MassSpectometry/No1/config_extended.json
+++ b/MassSpectometry/No1/config_extended.json
@@ -9,7 +9,7 @@
   "timeout_sec": "600",
   "solutions_dir_path": "./MassSpectometry/No1/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No1/config_full_bio.tools.json
+++ b/MassSpectometry/No1/config_full_bio.tools.json
@@ -9,7 +9,7 @@
   "timeout_sec": "3600",
   "solutions_dir_path": "./MassSpectometry/No1/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No1/config_original.json
+++ b/MassSpectometry/No1/config_original.json
@@ -9,7 +9,7 @@
   "timeout_sec": "120",
   "solutions_dir_path": "./MassSpectometry/No1/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No2/config_extended.json
+++ b/MassSpectometry/No2/config_extended.json
@@ -9,7 +9,7 @@
   "timeout_sec": "600",
   "solutions_dir_path": "./MassSpectometry/No2/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No2/config_full_bio.tools.json
+++ b/MassSpectometry/No2/config_full_bio.tools.json
@@ -9,7 +9,7 @@
   "timeout_sec": "3600",
   "solutions_dir_path": "./MassSpectometry/No2/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No2/config_original.json
+++ b/MassSpectometry/No2/config_original.json
@@ -9,7 +9,7 @@
   "timeout_sec": "120",
   "solutions_dir_path": "./MassSpectometry/No2/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No3/config_extended.json
+++ b/MassSpectometry/No3/config_extended.json
@@ -9,7 +9,7 @@
   "timeout_sec": "600",
   "solutions_dir_path": "./MassSpectometry/No3/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No3/config_full_bio.tools.json
+++ b/MassSpectometry/No3/config_full_bio.tools.json
@@ -9,7 +9,7 @@
   "timeout_sec": "3600",
   "solutions_dir_path": "./MassSpectometry/No3/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No3/config_original.json
+++ b/MassSpectometry/No3/config_original.json
@@ -9,7 +9,7 @@
   "timeout_sec": "120",
   "solutions_dir_path": "./MassSpectometry/No3/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No4/config_extended.json
+++ b/MassSpectometry/No4/config_extended.json
@@ -9,7 +9,7 @@
   "timeout_sec": "600",
   "solutions_dir_path": "./MassSpectometry/No4/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No4/config_full_bio.tools.json
+++ b/MassSpectometry/No4/config_full_bio.tools.json
@@ -9,7 +9,7 @@
   "timeout_sec": "3600",
   "solutions_dir_path": "./MassSpectometry/No4/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/MassSpectometry/No4/config_original.json
+++ b/MassSpectometry/No4/config_original.json
@@ -9,7 +9,7 @@
   "timeout_sec": "120",
   "solutions_dir_path": "./MassSpectometry/No4/",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "1000",
+  "solutions": "1000",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "10",
   "debug_mode": "true",

--- a/QuAnGIS/No1/config.json
+++ b/QuAnGIS/No1/config.json
@@ -13,7 +13,7 @@
   ],
   "timeout_sec": "300",
   "solution_length": { "min": 1, "max": 10 },
-  "max_solutions": "5",
+  "solutions": "5",
   "number_of_execution_scripts": "0",
   "number_of_generated_graphs": "5",
   "inputs": [    


### PR DESCRIPTION
The APE configuration file had an element `max_solutions` this has been renamed to `solutions` because it is a more accurate description. This has been changed in [this PR](https://github.com/sanctuuary/APE/pull/57). The use cases need to be updated as well.